### PR TITLE
Externalize assets and add tooling and authentication

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/__tests__/markdown-parser.test.js
+++ b/__tests__/markdown-parser.test.js
@@ -1,0 +1,26 @@
+import {
+  parseMarkdownToList,
+  parseMarkdownFromTable,
+} from '../js/markdown-parser.js';
+
+describe('parseMarkdownToList', () => {
+  test('parses headings and nested questions', () => {
+    const md = '## Heading\n1. Main?\n   a. Sub?\n   - Detail';
+    const result = parseMarkdownToList(md);
+    expect(result[0]).toEqual({ isHeading: true, text: 'Heading' });
+    const main = result[1];
+    expect(main.id).toBe('1');
+    expect(main.children[0].id).toBe('1a');
+    expect(main.children[0].children[0].id).toBe('1a-1');
+  });
+});
+
+describe('parseMarkdownFromTable', () => {
+  test('parses table rows into questions', () => {
+    const md = '## Heading\n| 1 | Question one |\n| 2 | Question two |';
+    const result = parseMarkdownFromTable(md);
+    expect(result[0]).toEqual({ isHeading: true, text: 'Heading' });
+    expect(result[1].id).toBe('1');
+    expect(result[2].text).toBe('Question two');
+  });
+});

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,83 @@
+/* Simple transition for showing/hiding elements */
+.hidden {
+  display: none;
+}
+.sub-question {
+  padding-left: 1.5rem;
+  border-left: 2px solid #e5e7eb;
+  margin-left: 0.5rem;
+}
+/* Style for active buttons */
+.program-btn.active,
+.tab-btn.active {
+  font-weight: 600;
+}
+.program-btn.active {
+  background-color: #2563eb;
+  color: white;
+}
+.tab-btn.active {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+/* Custom styles for headings and details/summary */
+.werkprogramma-heading {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid #d1d5db;
+}
+details > summary {
+  cursor: pointer;
+  list-style: none; /* Remove default marker */
+}
+details > summary::-webkit-details-marker {
+  display: none; /* Remove default marker for Chrome */
+}
+details > summary::before {
+  content: '▶';
+  margin-right: 0.5rem;
+  font-size: 0.8em;
+  display: inline-block;
+  transition: transform 0.2s;
+}
+details[open] > summary::before {
+  transform: rotate(90deg);
+}
+/* Mock Toast/Notification Style */
+#toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 12px 24px;
+  border-radius: 8px;
+  background-color: #2d3748;
+  color: white;
+  font-size: 1rem;
+  z-index: 100;
+  opacity: 0;
+  transition:
+    opacity 0.3s,
+    bottom 0.3s;
+}
+#toast.show {
+  opacity: 1;
+  bottom: 30px;
+}
+/* Disabled state for the form */
+#form-fieldset:disabled {
+  pointer-events: none;
+  opacity: 0.6;
+}
+/* Login screen layout */
+#login-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,11 @@
+export default [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      globals: { browser: true, node: true },
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {},
+  },
+];

--- a/index.html
+++ b/index.html
@@ -1,892 +1,209 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="nl">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Werkprogramma IB & VPB</title>
     <!-- Using Tailwind CSS for a clean, modern look -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        /* Simple transition for showing/hiding elements */
-        .hidden { display: none; }
-        .sub-question {
-            padding-left: 1.5rem;
-            border-left: 2px solid #e5e7eb;
-            margin-left: 0.5rem;
-        }
-        /* Style for active buttons */
-        .program-btn.active, .tab-btn.active {
-            font-weight: 600;
-        }
-        .program-btn.active {
-            background-color: #2563eb;
-            color: white;
-        }
-        .tab-btn.active {
-            border-color: #2563eb;
-            color: #2563eb;
-        }
-        /* Custom styles for headings and details/summary */
-        .werkprogramma-heading {
-            font-size: 1.25rem;
-            font-weight: 700;
-            color: #1f2937;
-            margin-top: 1.5rem;
-            margin-bottom: 0.5rem;
-            padding-bottom: 0.25rem;
-            border-bottom: 2px solid #d1d5db;
-        }
-        details > summary {
-            cursor: pointer;
-            list-style: none; /* Remove default marker */
-        }
-        details > summary::-webkit-details-marker {
-            display: none; /* Remove default marker for Chrome */
-        }
-        details > summary::before {
-            content: '▶';
-            margin-right: 0.5rem;
-            font-size: 0.8em;
-            display: inline-block;
-            transition: transform 0.2s;
-        }
-        details[open] > summary::before {
-            transform: rotate(90deg);
-        }
-        /* Mock Toast/Notification Style */
-        #toast {
-            position: fixed;
-            bottom: 20px;
-            left: 50%;
-            transform: translateX(-50%);
-            padding: 12px 24px;
-            border-radius: 8px;
-            background-color: #2d3748;
-            color: white;
-            font-size: 1rem;
-            z-index: 100;
-            opacity: 0;
-            transition: opacity 0.3s, bottom 0.3s;
-        }
-        #toast.show {
-            opacity: 1;
-            bottom: 30px;
-        }
-        /* Disabled state for the form */
-        #form-fieldset:disabled {
-            pointer-events: none;
-            opacity: 0.6;
-        }
-    </style>
-</head>
-<body class="bg-gray-100 font-sans">
-
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body class="bg-gray-100 font-sans">
     <!-- Main Application Container -->
     <div id="app-container">
-        <!-- Dashboard Screen -->
-        <div id="dashboard-screen" class="container mx-auto p-4 md:p-8">
-             <header class="bg-white p-6 rounded-lg shadow-md">
-                <div class="flex flex-wrap justify-between items-center gap-4">
-                    <div>
-                        <h1 class="text-3xl font-bold text-gray-800">Dashboard</h1>
-                        <p class="text-gray-600 mt-2">Selecteer een werkprogramma en cliënt om te starten.</p>
-                    </div>
-                    <div class="text-sm text-right">
-                        <p class="font-semibold" id="user-display-dashboard"></p>
-                        <button id="btn-logout" class="text-xs text-blue-600 hover:underline">Uitloggen</button>
-                    </div>
+      <!-- Dashboard Screen -->
+      <div id="dashboard-screen" class="container mx-auto p-4 md:p-8">
+        <header class="bg-white p-6 rounded-lg shadow-md">
+          <div class="flex flex-wrap justify-between items-center gap-4">
+            <div>
+              <h1 class="text-3xl font-bold text-gray-800">Dashboard</h1>
+              <p class="text-gray-600 mt-2">
+                Selecteer een werkprogramma en cliënt om te starten.
+              </p>
+            </div>
+            <div class="text-sm text-right">
+              <p class="font-semibold" id="user-display-dashboard"></p>
+              <button
+                id="btn-logout"
+                class="text-xs text-blue-600 hover:underline"
+                aria-label="Uitloggen"
+              >
+                Uitloggen
+              </button>
+            </div>
+          </div>
+          <div class="mt-4 border-t pt-4">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div>
+                <label
+                  for="fiscal-year-select"
+                  class="block text-sm font-medium text-gray-700"
+                  >1. Kies Fiscaal Jaar</label
+                >
+                <div class="flex items-center gap-2 mt-1">
+                  <select
+                    id="fiscal-year-select"
+                    class="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md"
+                    aria-label="Fiscaal jaar"
+                  ></select>
+                  <button
+                    id="btn-add-year"
+                    class="hidden bg-green-500 text-white p-2 rounded-md hover:bg-green-600 transition text-sm"
+                    aria-label="Voeg jaar toe"
+                  >
+                    +
+                  </button>
                 </div>
-                <div class="mt-4 border-t pt-4">
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700">1. Kies Fiscaal Jaar</label>
-                            <div class="flex items-center gap-2 mt-1">
-                                <select id="fiscal-year-select" class="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md"></select>
-                                <button id="btn-add-year" class="hidden bg-green-500 text-white p-2 rounded-md hover:bg-green-600 transition text-sm">+</button>
-                            </div>
-                        </div>
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700">2. Kies Werkprogramma</label>
-                            <div class="mt-1 flex space-x-2">
-                                <button id="btn-ib" class="program-btn flex-1 py-2 px-4 rounded-md bg-gray-200 text-gray-700 hover:bg-gray-300 transition">IB</button>
-                                <button id="btn-vpb" class="program-btn flex-1 py-2 px-4 rounded-md bg-gray-200 text-gray-700 hover:bg-gray-300 transition">VPB</button>
-                            </div>
-                        </div>
-                        <div id="client-selection-container" class="hidden">
-                            <label for="client-select" class="block text-sm font-medium text-gray-700">3. Kies Cliënt</label>
-                            <select id="client-select" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md">
-                                <option value="">-- Selecteer --</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="mt-6 text-right">
-                        <button id="btn-open-werkprogramma" class="bg-blue-600 text-white font-bold py-2 px-6 rounded-lg hover:bg-blue-700 transition disabled:bg-gray-400" disabled>
-                            Open Werkprogramma
-                        </button>
-                    </div>
+              </div>
+              <div>
+                <label
+                  class="block text-sm font-medium text-gray-700"
+                  for="btn-ib"
+                  >2. Kies Werkprogramma</label
+                >
+                <div class="mt-1 flex space-x-2">
+                  <button
+                    id="btn-ib"
+                    class="program-btn flex-1 py-2 px-4 rounded-md bg-gray-200 text-gray-700 hover:bg-gray-300 transition"
+                    aria-label="Selecteer IB"
+                  >
+                    IB
+                  </button>
+                  <button
+                    id="btn-vpb"
+                    class="program-btn flex-1 py-2 px-4 rounded-md bg-gray-200 text-gray-700 hover:bg-gray-300 transition"
+                    aria-label="Selecteer VPB"
+                  >
+                    VPB
+                  </button>
                 </div>
-            </header>
-        </div>
+              </div>
+              <div id="client-selection-container" class="hidden">
+                <label
+                  for="client-select"
+                  class="block text-sm font-medium text-gray-700"
+                  >3. Kies Cliënt</label
+                >
+                <select
+                  id="client-select"
+                  class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md"
+                >
+                  <option value="">-- Selecteer --</option>
+                </select>
+              </div>
+            </div>
+            <div class="mt-6 text-right">
+              <button
+                id="btn-open-werkprogramma"
+                class="bg-blue-600 text-white font-bold py-2 px-6 rounded-lg hover:bg-blue-700 transition disabled:bg-gray-400"
+                aria-label="Open werkprogramma"
+                disabled
+              >
+                Open Werkprogramma
+              </button>
+            </div>
+          </div>
+        </header>
+      </div>
 
-        <!-- Werkprogramma Screen (initially hidden) -->
-        <div id="werkprogramma-screen" class="hidden container mx-auto p-4 md:p-8">
-            <header class="bg-white p-6 rounded-lg shadow-md mb-8">
-                <div class="flex flex-wrap justify-between items-center gap-4">
-                    <div>
-                        <button id="btn-back-to-dashboard" class="text-sm text-blue-600 hover:underline mb-2">&larr; Terug naar Dashboard</button>
-                        <h1 class="text-3xl font-bold text-gray-800">Werkprogramma</h1>
-                        <p id="header-subtitle" class="text-gray-600 mt-2"></p>
-                        <div id="dossier-status-container" class="hidden mt-2 text-sm">
-                            Huidige status: <span id="dossier-status-badge" class="font-bold px-2 py-1 rounded-full"></span>
-                        </div>
-                    </div>
-                    <div class="flex items-center gap-4">
-                        <div class="text-sm">
-                            <p class="font-semibold" id="user-display-werkprogramma"></p>
-                            <input type="text" id="api-key-input" placeholder="X-API-KEY (AuditCase)" class="mt-1 text-xs p-1 border rounded-md w-48">
-                        </div>
-                        <div class="flex items-center gap-2">
-                             <input type="file" id="import-file" class="hidden" accept=".txt">
-                             <label for="import-file" class="cursor-pointer bg-gray-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-600 transition">Importeren (TXT)</label>
-                             <button id="btn-export" class="bg-gray-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-600 transition">Exporteren (TXT)</button>
-                        </div>
-                        <div id="action-buttons" class="flex items-center gap-2">
-                            <button id="btn-submit" class="hidden bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition">Indienen</button>
-                            <button id="btn-review" class="hidden bg-green-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-green-700 transition">Reviewen</button>
-                            <button id="btn-close" class="hidden bg-red-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-700 transition">Afsluiten</button>
-                            <button id="btn-reopen" class="hidden bg-yellow-500 text-black font-bold py-2 px-4 rounded-lg hover:bg-yellow-600 transition">Heropenen</button>
-                        </div>
-                    </div>
-                </div>
-            </header>
-            <main id="werkprogramma-container" class="bg-white p-6 rounded-lg shadow-md min-h-[200px]"></main>
-        </div>
+      <!-- Werkprogramma Screen (initially hidden) -->
+      <div
+        id="werkprogramma-screen"
+        class="hidden container mx-auto p-4 md:p-8"
+      >
+        <header class="bg-white p-6 rounded-lg shadow-md mb-8">
+          <div class="flex flex-wrap justify-between items-center gap-4">
+            <div>
+              <button
+                id="btn-back-to-dashboard"
+                class="text-sm text-blue-600 hover:underline mb-2"
+                aria-label="Terug naar dashboard"
+              >
+                &larr; Terug naar Dashboard
+              </button>
+              <h1 class="text-3xl font-bold text-gray-800">Werkprogramma</h1>
+              <p id="header-subtitle" class="text-gray-600 mt-2"></p>
+              <div id="dossier-status-container" class="hidden mt-2 text-sm">
+                Huidige status:
+                <span
+                  id="dossier-status-badge"
+                  class="font-bold px-2 py-1 rounded-full"
+                ></span>
+              </div>
+            </div>
+            <div class="flex items-center gap-4">
+              <div class="text-sm">
+                <p class="font-semibold" id="user-display-werkprogramma"></p>
+                <input
+                  type="text"
+                  id="api-key-input"
+                  placeholder="X-API-KEY (AuditCase)"
+                  class="mt-1 text-xs p-1 border rounded-md w-48"
+                  aria-label="AuditCase API sleutel"
+                />
+              </div>
+              <div class="flex items-center gap-2">
+                <input
+                  type="file"
+                  id="import-file"
+                  class="hidden"
+                  accept=".txt"
+                  aria-label="Importeer dossier"
+                />
+                <label
+                  for="import-file"
+                  class="cursor-pointer bg-gray-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-600 transition"
+                  >Importeren (TXT)</label
+                >
+                <button
+                  id="btn-export"
+                  class="bg-gray-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-600 transition"
+                  aria-label="Exporteer dossier"
+                >
+                  Exporteren (TXT)
+                </button>
+              </div>
+              <div id="action-buttons" class="flex items-center gap-2">
+                <button
+                  id="btn-submit"
+                  class="hidden bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition"
+                  aria-label="Indienen"
+                >
+                  Indienen
+                </button>
+                <button
+                  id="btn-review"
+                  class="hidden bg-green-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-green-700 transition"
+                  aria-label="Reviewen"
+                >
+                  Reviewen
+                </button>
+                <button
+                  id="btn-close"
+                  class="hidden bg-red-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-700 transition"
+                  aria-label="Afsluiten"
+                >
+                  Afsluiten
+                </button>
+                <button
+                  id="btn-reopen"
+                  class="hidden bg-yellow-500 text-black font-bold py-2 px-4 rounded-lg hover:bg-yellow-600 transition"
+                  aria-label="Heropenen"
+                >
+                  Heropenen
+                </button>
+              </div>
+            </div>
+          </div>
+        </header>
+        <main
+          id="werkprogramma-container"
+          class="bg-white p-6 rounded-lg shadow-md min-h-[200px]"
+        ></main>
+      </div>
     </div>
-    
+
     <div id="toast"></div>
-
-    <script>
-        // --- Data store for all markdown content ---
-        const CONTENT_DATA = {
-            client: `
-## Klant acceptatie
-1. Is de opdrachtbevestiging getekend en opgeslagen in het dossier?
-2. Is er een kopie van het paspoort of identiteitsbewijs van de cliënt aanwezig?
-3. Is de UBO (Ultimate Beneficial Owner) vastgesteld en gedocumenteerd?
-    a. Zijn de UBO-verklaringen compleet en ondertekend?
-4. Is het KYC (Know Your Customer) proces volledig doorlpen?
-    a. Is de cliënt gecontroleerd op PEP (Politically Exposed Person) en sanctielijsten?
-    b. Is de uitkomst van de Wwft-check vastgelegd?
-`,
-            ib: `
-## Algemeen
-1. Is cliënt het hele jaar of een gedeelte van het jaar gehuwd? Zo nee, ga naar vraag 6
-2. Is cliënt gehuwd in gemeenschap van goederen?
-3. Onder huwelijkse voorwaarden (kopie in permanent dossier)?
-4. Is cliënt dit jaar gehuwd? Zo ja per welke datum?
-5. a. Is cliënt dit jaar gescheiden?
-   b. Zo ja, is een verzoek tot echtscheiding/scheiding tafel en bed ingediend?
-   c. Zo ja, is cliënt niet meer woonachtig op hetzelfde woonadres in het bevolkingsregister?
-6. Is cliënt ongehuwd samenwonend? Zo nee: ga naar vraag 12
-7. Is er een notarieel samenlevingscontract (kopie in permanent dossier)?
-8. Staat cliënt en partner op hetzelfde woonadres in het bevolkingsregister? Hele jaar?
-9. Is cliënt dit jaar gaan samenwonen? Vanaf wanneer?
-10. Is cliënt dit jaar uit elkaar gegaan? Vanaf wanneer?
-11. Hebben cliënt en partner samen kind of een kind erkend van de ander?
-12. Staat de partner van de cliënt als partner in diens pensioenregeling?
-13. Hebben cliënt en partner samen een eigen woning?
-14. Zijn gegevens kinderen ingevuld (geb. datum, bsn, voorletters) in FiscaalGemak?
-    a. Is aangegeven of sprake is van een thuiswonend kind (onderdeel heffingskortingen)?
-    b. Bij co-ouderschap: is beoordeeld of de inkomensafhankelijke combinatiekorting kan worden geclaimd bij de ouder waar het kind niet staat ingeschreven?
-15. Heeft cliënt een testament opgemaakt (kopie in permanent dossier)?
-## Verliesverrekening
-16. Is er sprake van verlies in voorgaande jaren? Zo nee, ga naar vraag 18
-17. Zijn de verliezen van voorgaande jaren goed ingevuld conform de verliesbeschikkingen en zijn de definitieve aanslagen in het dossier opgenomen?
-18. Is er dit jaar sprake van een verlies? Zo nee, ga naar vraag 20
-19. Is het belastbaar inkomen uit het verleden goed ingevuld conform de definitieve aanslagen?
-20. Nog te verrekenen persoonsgebonden aftrek voorgaande jaren? Zo ja, ingevuld in aangifte?
-## Box I aandachtspunten
-21. Is er sprake van winst uit onderneming? Zo nee, ga naar vraag 22
-    a. Jaarstukken
-       - Zijn alle jaarstukken ingevoerd?
-       - Btw-positie gespecificeerd in jaarstuk?
-       - Sluit het resultaat van het jaarstuk met de aangifte in aangifteprogramma?
-       - Is de jaarrekening al door vennoot/afdelingshoofd nagekeken?
-    b. Aangifte
-       - Voldoet cliënt aan urencriterium en licht toe waarom?
-       - Is de landbouwvrijstelling toegepast? Zo ja, licht toe
-       - Uitgesloten of beperkt aftrekbare kosten ingevuld?
-       - Willekeurige afschrijving van toepassing? Zo ja, licht toe
-       - Afschrijving gebouwen/bodemwaarde ingevuld?
-       - Kleinschaligheidsinvesteringsaftrek van toepassing?
-       - Milieu- of Energieinvesteringsaftrek van toepassing?
-       - Desinvesteringsbijtelling van toepassing?
-       - Zelfstandigenaftrek van toepassing?
-       - Startersaftrek van toepassing? Zo ja, licht toe hoeveel jaar nog
-       - Startersaftrek arbeidsongeschiktheid van toepassing?
-       - Aftrek S&O van toepassing?
-       - Meewerkaftrek of meewerkbeloning mogelijk? Zo ja, licht toe
-       - In geval van staking: is de stakingswinst goed onderbouwd en aangegeven?
-       - Stakingsaftrek toegepast? Licht toe
-       - FOR op balans? Let op hoogte ondernemingsvermogen
-       - (Inhaal)dotatie FOR toegepast? Zo nee, licht toe
-       - Vrijval FOR (verplicht of vrijwillig)? Licht toe
-       - Privégebruik auto goed verwerkt in aangifteprogramma
-       - Is werkruimte een zelfstandig deel van de woning? Licht toe
-       - Wordt er een HIR gevormd of benut? Zo nee, ga naar vraag 22
-       - HIR gevormd: ligt het vervangingsvoornemen goed vast in het dossier?
-       - HIR benut: is deze goed verwerkt in aangifteprogramma?
-       - Is rekening gehouden met boekwaarde-eis/willekeurige afschrijving verleden?
-22. Is er sprake van loon of inkomen uit vroegere dienstbetrekking? Zo nee, ga naar vraag 23
-    - Jaaropgaven in dossier?
-    - Als werknemer met openbaar vervoer reist: verklaring in dossier?
-    - Is er sprake van een dga? Zo nee, ga naar vraag 23
-    - Is de gebruikelijkloonregeling van toepassing?
-    - Is de hoogte van het gebruikelijk loon nog te beoordelen?
-23. Is er sprake van resultaat uit overige werkzaamheden? Zo nee, ga naar vraag 24
-    - Jaaropgaven in dossier
-    - Balans/resultaat per werkzaamheid ingevuld
-    - Is werkruimte een zelfstandig deel van de woning? Licht toe
-    - Dga: is rekening-courant gedurende het jaar maximaal €17.500?
-    - Is sprake van een vordering op de bv? Zakelijke leningovereenkomst aanwezig?
-    - Is er sprake van een tbs-pand? Zo nee, ga naar vraag 24
-        a. Is de huur zakelijk? Licht toe
-        b. Huurovereenkomst aanwezig in permanent dossier?
-        c. Rekening gehouden met kostenaftrek (hypotheekrente e.d.)?
-        d. Afschrijvingen beoordeeld (bodemwaarde en afschrijvingsbeperking)?
-        e. Schulden toegerekend aan het pand?
-        f. Voorziening voor groot onderhoud noodzakelijk?
-24. Is er sprake van (negatieve) uitgaven inkomensvoorziening? Zo nee, ga naar vraag 25
-    A. Lijfrente
-       - Jaar- en reserveringsruimte ingevuld?
-       - Lijfrentepolis in permanent dossier?
-       - Lijfrente niet aftrekbaar: afname FOR mogelijk?
-       - Stakingslijfrente aanwezig?
-    B. Premies arbeidsongeschiktheidsverzekering betaald?
-       - Betalingsbewijs in dossier?
-       - Polis aov in permanent dossier?
-    C. Terugontvangen premies? Licht toe
-25. Inkomsten uit eigen woning
-    - Is er een eigenwoningreserve uit het verleden?
-    - Is er een aflossingsstand? Licht toe
-    - Is er sprake van een eigen woning? Zo nee, ga naar vraag 26
-    - WOZ-beschikking in dossier?
-    - Is sprake van een oude lening (niet verplicht annuïtair)?
-    - Is sprake van een nieuwe lening (verplicht annuïtair)?
-    - Overzicht betaalde hypotheekrente in dossier?
-    - Vrijgestelde schenking voor de eigen woning ontvangen? Licht toe
-    - Eigen woning verkocht of gekocht dit jaar? Licht toe
-    - Staat eigen woning leeg te koop of in aanbouw? Licht toe
-    - Hypotheek dit jaar verhoogd? Onderbouwing in dossier?
-    - Overzicht looptijd renteaftrek leningen bijgewerkt?
-    - Kapitaalverzekering eigen woning? Polis in permanent dossier?
-    - Bijleenregeling van toepassing en ingevuld?
-    - Is er sprake van een ondernemer of resultaatgenieter?
-    - Geen zelfstandige werkruimte: 100% WOZ toegepast?
-26. Is er sprake van periodieke uitkeringen en verstrekkingen? Zo nee, ga naar vraag 27
-    - Alimentatie ontvangen? (voor kinderen niet belast)
-    - Echtscheidingsconvenant aanwezig in permanent dossier?
-    - Overige periodieke uitkeringen die niet onder de loonheffing vallen?
-## Box II aandachtspunten
-27. Is er sprake van een aanmerkelijk belang? Zo nee, ga naar vraag 28
-    - Aantal aandelen ingevuld in aangifteprogramma?
-    - Verkrijgingsprijs aanmerkelijk belang ingevuld?
-    a. Regulier voordeel? Zo ja:
-       - Aangifte(n) dividendbelasting in dossier?
-       - Rente betaald voor aankoop AB-aandelen? Onderbouwing aanwezig?
-       - Andere winstuitkeringen of forfaitair rendement buitenlandse beleggingsinstelling?
-    b. (Fictief) vervreemdingsvoordeel? Zo ja:
-       - Verkoopovereenkomst in permanent dossier?
-       - Akte van levering in permanent dossier?
-       - Kosten in mindering op overdrachtsprijs gebracht?
-## Box III aandachtspunten
-28. Is er sprake van bezittingen? Zo nee, ga naar vraag 29
-    a. Jaaropgave(n) banksaldi in dossier?
-    b. Jaaropgave(n) effecten in dossier?
-       - Nederlandse dividendbelasting ingevuld?
-    c. Woningen (geen eigen woning) WOZ-waarde of WEV?
-       - Verhuur of pacht? Leegwaarderatio toegepast?
-    d. Overige onroerende zaken: WEV. Onderbouwing van waarde?
-    e. Vrijgestelde kapitaalverzekering (niet eigen woning)? Polis in dossier?
-    f. Kapitaalverzekering boven vrijstelling?
-       - Polis in dossier?
-       - Belaste waarde ingevuld?
-       - Onderbouwing/jaaropgave in dossier?
-    g. Vorderingen of verstrekte leningen? Specificatie aanwezig?
-    h. Contant geld of cryptovaluta aanwezig?
-    i. Overige relevante bezittingen (bijv. VvE-aandeel)?
-    j. Aandeel onverdeelde boedel aanwezig? Berekening in dossier?
-    k. Vruchtgebruik/bloot eigendom van toepassing? Berekening in dossier?
-    l. Vermogen in het buitenland?
-29. Is er sprake van schulden? Zo nee, ga naar vraag 30
-    - Jaaropgave(n) banksaldi in dossier
-    - Specificatie rekening-courant directie in dossier
-    - Jaaropgave(n) overige schulden in dossier
-30. Vrijstellingen
-    - Gedefiscaliseerd: verkrijgingen krachtens erfrecht
-    - Vrijstelling groene beleggingen van toepassing? Jaaropgave in dossier?
-    - Heffingskorting groenbeleggingen ingevuld?
-## Vermogen
-31. Is het vermogen sterk toe- of afgenomen? Zo ja, verklaring in dossier aanwezig?
-## Persoonsgebonden aftrek
-32. Alimentatie betaald aan ex-partner?
-    - Betalingsbewijzen en echtscheidingsconvenant in dossier?
-    - Specifieke zorgkosten ingevuld? Onderbouwing in dossier?
-    - Weekenduitgaven gehandicapten > 21 jaar van toepassing? Licht toe
-    - Scholingsuitgaven van toepassing? Vastlegging in dossier (tot 2022)
-    - Periodieke gift? Stukken in dossier
-    - Reguliere giften? Betalingsbewijzen en ANBI/SBBI controle
-## Heffingskortingen
-33. Levensloop (deels) opgenomen? Levensloopkorting toegepast? (tot 2022)
-    - Alleenstaande ouderenkorting bij AOW ongehuwden geclaimd?
-    - Jonggehandicaptenkorting geclaimd indien van toepassing?
-## Bijzondere situaties en voorheffingen
-34. Betrokken bij trustvermogen?
-    - Buitenlandse dividendbelasting ingevuld bij voorkoming dubbele belasting?
-    - Buitenlands inkomen? Voorkoming dubbele belasting?
-    - Inkomen waarover revisierente verschuldigd is?
-    - Bezittingen in het buitenland? Voorkoming dubbele belasting?
-    - Geen aanmerkelijk belang meer? Verlies uit AB verrekend of belastingkorting verzocht?
-## Diversen
-35. Heeft overheveling van box III naar box I of II plaatsgevonden of andersom? Licht toe
-    - Voorlopige aanslagen IB/ZVW ingevuld?
-    - Dienen voorlopige aanslagen verhoogd of verlaagd te worden?
-    - Is middeling mogelijk?
-    - Recht op zorgtoeslag, huurtoeslag of kindgebonden budget? Actie noodzakelijk?
-    - Is de verdeling fiscaal optimaal? (Laatste stap vóór review)
-    - Is de aangifte gevalideerd?
-`,
-            vpb: `
-## Fiscale eenheid Vpb
-| 1 | Is er sprake van een fiscale eenheid Vpb? Zo ja, onderstaande vragen beantwoorden |
-| 2 | Zijn er ondernemingen gevoegd of ontvoegd in het boekjaar? |
-| 3 | Hebben er verschuivingen plaatsgevonden binnen de fiscale eenheid van vermogensbestanddelen of HIR? Denk bijv. aan: onderneming (doorzakking), onroerend goed, machines/inventaris. Zo ja, licht toe |
-## Concern
-| 4 | Is er sprake van een concern (meerdere bv's)? Zo ja, onderstaande vragen beantwoorden |
-| 5 | Vinden er transacties plaats binnen het concern/tussen gelieerde personen maar buiten de fiscale eenheid Vpb?<br>Zo ja, zijn deze transacties op zakelijke gronden en marktprijzen? |
-| 6 | Is er sprake van (een) concernfinanciering(en) buiten fiscale eenheid Vpb?<br>- Is er sprake van een marktconforme rente?<br>- Zijn er voldoende zekerheden verstrekt?<br>- Zijn de overeenkomsten aanwezig in permanent dossier? |
-## Aandeelhouders en deelnemingen
-| 7 | Heeft de onderneming aandeelhouders? Zo ja, is de specificatie ingevuld (ook de schuld/vordering (R/C) posities en uitgekeerd dividend)? |
-| 8 | Heeft de onderneming deelnemingen? Zo ja, is de specificatie ingevuld (ook de schuld/vordering (R/C) posities en uitgekeerd dividend)?<br>Indien sprake is van deelnemingen, is toepassing van de deelnemingsvrijstelling beoordeeld? |
-## Jaarrekening(en)
-| 9 | Is de afschrijvingsstaat in het dossier opgenomen? |
-| 10 | Zijn de restwaarde en/of bodemwaarde ingevuld in de aangifte en beoordeeld? |
-## Deelnemingen
-| 16 | Zijn de deelnemingen fiscaal gewaardeerd op kostprijs in de aangifte? |
-| 17 | Indien een deelneming vergroot/aangeschaft/verkleind/vervreemd is, zijn dan de kosten gecorrigeerd (niet aftrekbaar)? |
-## Vorderingen
-| 19 | Is de nominale waarde van de debiteuren/vorderingen opgenomen in de aangifte? |
-| 20 | Is de rente op de leningen zakelijk (denk aan: zekerheid, marktconforme rente, aflossingscapaciteit)? |
-## Passiva
-| 21 | Sluit het fiscale beginvermogen in de aangifte aan met de aangifte van voorgaand jaar? |
-## Fiscale voorzieningen
-| 22 | Zo ja, is er een onderbouwing in het dossier en voldoen ze aan de fiscale eisen? |
-| 23 | Onderhoudsvoorziening = onderhoudsplan aanwezig in permanent dossier? |
-## Schulden
-| 27 | Zit de rondrekening omzetbelasting in het dossier? Is de specificatie omzetbelasting in de aangifte ingevuld? |
-| 28 | Is sprake van een lening? Zo ja, is de lening zakelijk (denk aan: zekerheid, marktconforme rente, aflossingscapaciteit)? |
-## Vermogensvergelijking
-| 29 | Zijn alle jaarstukken ingevoerd in het aangifteprogramma? |
-| 30 | Is de jaarrekening al door partner/accountant nagekeken? |
-## Fiscale winstberekening
-| 34 | Zijn dividenduitkeringen, terugbetalingen van kapitaal aan aandeelhouders of kapitaalstortingen door aandeelhouders verwerkt? Zo ja, zijn de specificaties opgenomen in het dossier? |
-| 35 | Is de balanspositie van de Vpb ingevuld in het aangifteprogramma (bij niet aftrekbare bedragen/Vpb)? |
-## Verliesverrekening
-| 42 | Is er sprake van verlies in voorgaande jaren? |
-| 43 | Zijn de verliezen van voorgaande jaren goed ingevuld conform de verliesbeschikkingen |
-## Algemeen/berekening belastingbedrag
-| 47 | Als er sprake is van belegging in aandelen, is de Nederlandse dividendbelasting meegenomen in de voorheffingen en de buitenlandse bronheffing onder voorkoming dubbele belasting? |
-| 48 | Zijn de voorlopige aanslagen opgenomen/beoordeeld in het aangifteprogramma? |
-## Buitenlandse activiteiten
-| 52 | Zijn er buitenlandse activiteiten (vaste inrichting)?<br>Is documentatie transfer pricing aanwezig? |
-| 53 | Is er sprake van voorkoming dubbele belastingen (elders belast)? |
-`
-        };
-
-        document.addEventListener('DOMContentLoaded', () => {
-            // --- App State ---
-            let currentProgram = null;
-            let currentUser = null;
-            let dossierStatus = 'open'; // 'open', 'ingediend', 'gereviewd', 'afgesloten'
-            let availableYears = [];
-
-            // --- DOM Element References ---
-            const dom = {
-                dashboardScreen: document.getElementById('dashboard-screen'),
-                werkprogrammaScreen: document.getElementById('werkprogramma-screen'),
-                btnLogout: document.getElementById('btn-logout'),
-                userDisplayDashboard: document.getElementById('user-display-dashboard'),
-                userDisplayWerkprogramma: document.getElementById('user-display-werkprogramma'),
-                apiKeyInput: document.getElementById('api-key-input'),
-                fiscalYearSelect: document.getElementById('fiscal-year-select'),
-                btnAddYear: document.getElementById('btn-add-year'),
-                btnIb: document.getElementById('btn-ib'),
-                btnVpb: document.getElementById('btn-vpb'),
-                clientSelectionContainer: document.getElementById('client-selection-container'),
-                clientSelect: document.getElementById('client-select'),
-                btnOpenWerkprogramma: document.getElementById('btn-open-werkprogramma'),
-                btnBackToDashboard: document.getElementById('btn-back-to-dashboard'),
-                headerSubtitle: document.getElementById('header-subtitle'),
-                werkprogrammaContainer: document.getElementById('werkprogramma-container'),
-                dossierStatusContainer: document.getElementById('dossier-status-container'),
-                dossierStatusBadge: document.getElementById('dossier-status-badge'),
-                btnSubmit: document.getElementById('btn-submit'),
-                btnReview: document.getElementById('btn-review'),
-                btnClose: document.getElementById('btn-close'),
-                btnReopen: document.getElementById('btn-reopen'),
-                btnExport: document.getElementById('btn-export'),
-                importFile: document.getElementById('import-file'),
-            };
-
-            // --- Data ---
-            const users = {
-                alice: { name: "Alice (Opsteller)", role: "opsteller" },
-                bob: { name: "Bob (Reviewer)", role: "reviewer" },
-                charlie: { name: "Charlie (Admin)", role: "admin" }
-            };
-            const clients = {
-                ib: ["Jan Jansen", "Pim Jansen", "Anne de Jong"],
-                vpb: ["Test B.V.", "Test 2 B.V.", "Holding X B.V."]
-            };
-            const permissions = {
-                opsteller: { canSubmit: true, canReview: false, canClose: false, canReopen: false, canAddYear: false },
-                reviewer: { canSubmit: true, canReview: true, canClose: true, canReopen: true, canAddYear: true },
-                admin: { canSubmit: true, canReview: true, canClose: true, canReopen: true, canAddYear: true }
-            };
-
-            // --- Initialization ---
-            function init() {
-                const storedUserId = localStorage.getItem('currentUser');
-                if (!storedUserId || !users[storedUserId]) {
-                    window.location.href = 'login.html';
-                    return;
-                }
-                currentUser = users[storedUserId];
-
-                const currentYear = new Date().getFullYear();
-                availableYears = [currentYear, currentYear - 1, currentYear - 2];
-                populateFiscalYears();
-
-                // Event Listeners
-                dom.btnLogout.addEventListener('click', handleLogout);
-                dom.btnAddYear.addEventListener('click', handleAddYear);
-                dom.btnIb.addEventListener('click', () => setupClientSelection('ib'));
-                dom.btnVpb.addEventListener('click', () => setupClientSelection('vpb'));
-                dom.clientSelect.addEventListener('change', () => {
-                    dom.btnOpenWerkprogramma.disabled = !dom.clientSelect.value;
-                });
-                dom.btnOpenWerkprogramma.addEventListener('click', openWerkprogramma);
-                dom.btnBackToDashboard.addEventListener('click', showDashboard);
-                dom.btnExport.addEventListener('click', handleExport);
-                dom.importFile.addEventListener('change', handleImport);
-
-                // Action button listeners
-                dom.btnSubmit.addEventListener('click', () => updateDossierStatus('ingediend', 'Dossier ingediend.'));
-                dom.btnReview.addEventListener('click', () => updateDossierStatus('gereviewd', 'Dossier gereviewd.'));
-                dom.btnClose.addEventListener('click', () => updateDossierStatus('afgesloten', 'Dossier afgesloten.'));
-                dom.btnReopen.addEventListener('click', () => {
-                    const reason = prompt("Reden voor heropenen:");
-                    if (reason && reason.trim() !== "") {
-                        console.log(`MOCK AUDIT TRAIL: Dossier heropend door ${currentUser.name}. Reden: ${reason}`);
-                        updateDossierStatus('open', 'Dossier heropend.');
-                    } else if (reason !== null) {
-                        showToast("Een reden is verplicht om het dossier te heropenen.");
-                    }
-                });
-
-                dom.userDisplayDashboard.textContent = `Ingelogd als: ${currentUser.name}`;
-                dom.userDisplayWerkprogramma.textContent = `Ingelogd als: ${currentUser.name}`;
-                dom.btnAddYear.classList.toggle('hidden', !permissions[currentUser.role].canAddYear);
-
-                showDashboard();
-            }
-
-            // --- Core Functions ---
-
-            function populateFiscalYears() {
-                dom.fiscalYearSelect.innerHTML = '';
-                availableYears.sort((a, b) => b - a).forEach(year => {
-                    dom.fiscalYearSelect.appendChild(new Option(year, year));
-                });
-            }
-
-            function handleLogout() {
-                currentUser = null;
-                localStorage.removeItem('currentUser');
-                window.location.href = 'login.html';
-            }
-
-            function handleAddYear() {
-                const latestYear = Math.max(...availableYears);
-                const newYear = prompt("Voer het nieuwe fiscale jaar in:", latestYear + 1);
-                if (newYear && !isNaN(newYear) && newYear > 1900) {
-                    const year = parseInt(newYear, 10);
-                    if (availableYears.includes(year)) {
-                        showToast(`Fiscaal jaar ${year} bestaat al.`);
-                        return;
-                    }
-                    availableYears.push(year);
-                    populateFiscalYears();
-                    dom.fiscalYearSelect.value = year;
-                    showToast(`Fiscaal jaar ${year} aangemaakt. Commentaren met 'doorrol' optie zijn (gesimuleerd) overgenomen.`);
-                } else if (newYear !== null) {
-                    showToast("Ongeldig jaartal ingevoerd.");
-                }
-            }
-
-            function showDashboard() {
-                dom.dashboardScreen.classList.remove('hidden');
-                dom.werkprogrammaScreen.classList.add('hidden');
-            }
-
-            function openWerkprogramma() {
-                if (!currentProgram || !dom.clientSelect.value) return;
-                dom.dashboardScreen.classList.add('hidden');
-                dom.werkprogrammaScreen.classList.remove('hidden');
-                dossierStatus = 'open';
-                loadAndRenderWorkProgram(currentProgram, dom.clientSelect.value, dom.fiscalYearSelect.value);
-            }
-
-            function setupClientSelection(programType) {
-                currentProgram = programType;
-                setActiveButton(programType === 'ib' ? dom.btnIb : dom.btnVpb, '.program-btn');
-                
-                dom.clientSelect.innerHTML = '<option value="">-- Selecteer --</option>';
-                clients[programType].forEach(client => {
-                    dom.clientSelect.appendChild(new Option(client, client));
-                });
-                
-                dom.clientSelectionContainer.classList.remove('hidden');
-                dom.btnOpenWerkprogramma.disabled = true;
-            }
-            
-            function updateDossierStatus(newStatus, toastMessage) {
-                dossierStatus = newStatus;
-                updateUIForRoleAndStatus();
-                showToast(toastMessage);
-            }
-
-            function updateUIForRoleAndStatus() {
-                if (!currentUser) return;
-                const rolePerms = permissions[currentUser.role];
-                const isLocked = dossierStatus === 'afgesloten';
-                
-                dom.dossierStatusBadge.textContent = dossierStatus.charAt(0).toUpperCase() + dossierStatus.slice(1);
-                dom.dossierStatusBadge.className = 'font-bold px-2 py-1 rounded-full ' + 
-                    (isLocked ? 'bg-red-200 text-red-800' : 'bg-green-200 text-green-800');
-                if (dom.clientSelect.value) {
-                    dom.dossierStatusContainer.classList.remove('hidden');
-                }
-
-                const fieldset = document.getElementById('form-fieldset');
-                if (fieldset) {
-                    fieldset.disabled = isLocked && currentUser.role === 'opsteller';
-                }
-
-                dom.btnSubmit.classList.toggle('hidden', !rolePerms.canSubmit || dossierStatus !== 'open');
-                dom.btnReview.classList.toggle('hidden', !rolePerms.canReview || dossierStatus !== 'ingediend');
-                dom.btnClose.classList.toggle('hidden', !rolePerms.canClose || dossierStatus !== 'gereviewd');
-                dom.btnReopen.classList.toggle('hidden', !rolePerms.canReopen || !isLocked);
-            }
-
-            async function loadAndRenderWorkProgram(type, clientName, fiscalYear) {
-                dom.werkprogrammaContainer.innerHTML = `<div class="text-center p-8"><p class="text-gray-500">Werkprogramma wordt geladen...</p></div>`;
-                dom.headerSubtitle.textContent = `Werkprogramma ${type.toUpperCase()} voor ${clientName} - Fiscaal Jaar ${fiscalYear}`;
-
-                try {
-                    await new Promise(resolve => setTimeout(resolve, 200));
-
-                    const clientQuestions = parseMarkdownToList(CONTENT_DATA.client);
-                    const taxQuestions = type === 'ib' ? parseMarkdownToList(CONTENT_DATA.ib) : parseMarkdownFromTable(CONTENT_DATA.vpb);
-                    
-                    dom.werkprogrammaContainer.innerHTML = `
-                        <fieldset id="form-fieldset">
-                            <div class="border-b border-gray-200">
-                                <nav class="-mb-px flex space-x-8" aria-label="Tabs">
-                                    <button id="tab-client" class="tab-btn whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">Klant</button>
-                                    <button id="tab-tax" class="tab-btn whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">Aangifte</button>
-                                </nav>
-                            </div>
-                            <div id="client-pane" class="content-pane py-4"></div>
-                            <div id="tax-pane" class="content-pane py-4 hidden"></div>
-                        </fieldset>
-                    `;
-
-                    const clientPane = document.getElementById('client-pane'), taxPane = document.getElementById('tax-pane');
-                    renderQuestions(clientQuestions, clientPane, 'client');
-                    renderQuestions(taxQuestions, taxPane, type);
-
-                    const tabClient = document.getElementById('tab-client'), tabTax = document.getElementById('tab-tax');
-                    
-                    setActiveButton(tabClient, '.tab-btn');
-                    tabClient.addEventListener('click', () => {
-                        setActiveButton(tabClient, '.tab-btn');
-                        clientPane.classList.remove('hidden');
-                        taxPane.classList.add('hidden');
-                    });
-                    tabTax.addEventListener('click', () => {
-                        setActiveButton(tabTax, '.tab-btn');
-                        clientPane.classList.add('hidden');
-                        taxPane.classList.remove('hidden');
-                    });
-                    
-                    updateUIForRoleAndStatus();
-
-                } catch (error) {
-                    console.error(`Failed to load work program for ${type}:`, error);
-                    dom.werkprogrammaContainer.innerHTML = '<p class="text-red-500 text-center">Fout bij het laden van het werkprogramma.</p>';
-                }
-            }
-
-            // --- Import/Export Functions ---
-            function handleExport() {
-                let content = `# Werkprogramma ${currentProgram.toUpperCase()} - ${dom.clientSelect.value}\n`;
-                content += `# Fiscaal Jaar: ${dom.fiscalYearSelect.value}\n`;
-                content += `# Status: ${dossierStatus}\n\n`;
-
-                document.querySelectorAll('.question-container').forEach(q => {
-                    const id = q.dataset.questionId;
-                    if (!id) return;
-                    const text = q.querySelector('p').textContent.replace(`${id}. `, '');
-                    const checkedRadio = q.querySelector(`input[name="answer-${id}"]:checked`);
-                    const comment = q.querySelector(`#comment-${id}`).value;
-                    const rollover = q.querySelector(`#comment-rollover-${id}`).checked;
-
-                    if(checkedRadio) {
-                        const answer = checkedRadio.parentElement.textContent.trim();
-                        content += `${id}. ${text}\n`;
-                        content += `   Antwoord: ${answer}\n`;
-                        content += `   Commentaar: ${comment}\n`;
-                        content += `   Doorrollen: ${rollover ? 'Ja' : 'Nee'}\n\n`;
-                    }
-                });
-                
-                const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
-                const a = document.createElement('a');
-                a.href = URL.createObjectURL(blob);
-                a.download = `werkprogramma-${dom.clientSelect.value.replace(/ /g, '_')}-${dom.fiscalYearSelect.value}.txt`;
-                a.click();
-                URL.revokeObjectURL(a.href);
-                showToast("Dossier geëxporteerd.");
-            }
-
-            function handleImport(event) {
-                const file = event.target.files[0];
-                if (!file) return;
-
-                const reader = new FileReader();
-                reader.onload = (e) => {
-                    const content = e.target.result;
-                    const lines = content.split('\n');
-                    let currentId = null;
-
-                    lines.forEach(line => {
-                        let match;
-                        if ((match = line.match(/^([0-9a-zA-Z]+)\./))) {
-                            currentId = match[1];
-                        } else if (currentId && (match = line.match(/^\s+Antwoord:\s(Ja|Nee|N\.v\.t\.)/i))) {
-                            const answer = match[1].toLowerCase().replace('n.v.t.', 'na');
-                            const radio = document.querySelector(`input[name="answer-${currentId}"][value="${answer}"]`);
-                            if(radio) {
-                                radio.checked = true;
-                                radio.dispatchEvent(new Event('change', { bubbles: true }));
-                            }
-                        } else if (currentId && (match = line.match(/^\s+Commentaar:\s(.*)/))) {
-                            const commentEl = document.getElementById(`comment-${currentId}`);
-                            if(commentEl) commentEl.value = match[1];
-                        } else if (currentId && (match = line.match(/^\s+Doorrollen:\s(Ja|Nee)/i))) {
-                            const rolloverEl = document.getElementById(`comment-rollover-${currentId}`);
-                            if(rolloverEl) rolloverEl.checked = match[1].toLowerCase() === 'ja';
-                        }
-                    });
-                    showToast("Dossier geïmporteerd.");
-                };
-                reader.readAsText(file);
-                event.target.value = ''; // Reset file input
-            }
-
-            // --- Utility & Parsing Functions ---
-
-            function setActiveButton(activeButton, selector) {
-                document.querySelectorAll(selector).forEach(btn => btn.classList.remove('active'));
-                if (activeButton) activeButton.classList.add('active');
-            }
-
-            function parseMarkdownToList(markdown) {
-                const lines = markdown.split('\n');
-                const questions = [];
-                const stack = [{ children: questions, level: -1 }];
-                const headingRegex = /^##\s+(.*)/, mainQRegex = /^(\d+)\.\s*(.*)/, subQRegex = /^\s+([a-zA-Z])\.\s*(.*)/, detailQRegex = /^\s+-\s*(.*)/;
-
-                lines.forEach(line => {
-                    let match;
-                    if ((match = line.match(headingRegex))) {
-                        questions.push({ isHeading: true, text: match[1].trim() });
-                        stack.length = 1;
-                    } else if ((match = line.match(mainQRegex))) {
-                        let text = match[2].trim();
-                        const condition = parseCondition(text);
-                        if (condition) text = text.replace(/Zo nee,.*|Zo ja,.*/i, '').trim();
-                        const question = { id: match[1], text, children: [], condition, level: 0 };
-                        questions.push(question);
-                        stack.length = 1; 
-                        stack.push(question);
-                    } else if ((match = line.match(subQRegex))) {
-                        while (stack.length > 2 && stack[stack.length - 1].level >= 1) { stack.pop(); }
-                        const parent = stack[stack.length - 1];
-                        const id = `${parent.id}${match[1]}`;
-                        const question = { id, text: match[2].trim(), children: [], level: parent.level + 1 };
-                        parent.children.push(question);
-                        stack.push(question);
-                    } else if ((match = line.match(detailQRegex))) {
-                         const parent = stack[stack.length - 1];
-                         const id = `${parent.id}-${parent.children.length + 1}`;
-                         parent.children.push({ id, text: match[1].trim(), level: parent.level + 1, isDetail: true });
-                    }
-                });
-                return questions;
-            }
-
-            function parseMarkdownFromTable(markdown) {
-                const lines = markdown.split('\n');
-                const questions = [];
-                const vpbQRegex = /^\|\s*(\d+)\s*\|([^|]+)\|/, headingRegex = /^##\s+(.*)/;
-                lines.forEach(line => {
-                    let match;
-                    if ((match = line.match(headingRegex))) {
-                        questions.push({ isHeading: true, text: match[1].trim() });
-                    } else if ((match = line.match(vpbQRegex))) {
-                        questions.push({ id: match[1].trim(), text: match[2].trim().replace(/<br>/g, ' '), children: [], level: 0 });
-                    }
-                });
-                return questions;
-            }
-
-            function parseCondition(text) {
-                const skipMatch = text.match(/Zo (nee|ja)[\s,:]*(?:ga naar vraag|ga naar)\s*(\d+)/i);
-                if (skipMatch) return { on: skipMatch[1].toLowerCase(), action: 'skip', target: skipMatch[2] };
-                if (/Zo nee, ga naar vraag \d+/.test(text)) return { on: 'no', action: 'hide_children' };
-                return null;
-            }
-
-            function renderQuestions(questions, container, type) {
-                questions.forEach(q => container.appendChild(createQuestionElement(q, type)));
-            }
-
-            function createQuestionElement(q, type) {
-                if (q.isHeading) {
-                    const heading = document.createElement('h2');
-                    heading.className = 'werkprogramma-heading';
-                    heading.textContent = q.text;
-                    return heading;
-                }
-                
-                const hasChildren = q.children && q.children.length > 0;
-                const questionWrapper = document.createElement(hasChildren ? 'details' : 'div');
-                questionWrapper.className = 'question-container py-4 border-b border-gray-200';
-                questionWrapper.id = `question-${q.id}`;
-                questionWrapper.dataset.questionId = q.id;
-
-                const contentWrapper = document.createElement(hasChildren ? 'summary' : 'div');
-                
-                const questionText = document.createElement('p');
-                questionText.className = 'font-semibold text-gray-700 inline';
-                questionText.textContent = q.isDetail ? q.text : `${q.id}. ${q.text}`;
-                contentWrapper.appendChild(questionText);
-
-                if (!q.isDetail) {
-                    const radioContainer = document.createElement('div');
-                    radioContainer.className = 'mt-2 flex items-center gap-x-6';
-                    radioContainer.innerHTML = `
-                        <label class="flex items-center space-x-2 cursor-pointer"><input type="radio" name="answer-${q.id}" value="yes" class="form-radio h-4 w-4 text-blue-600"><span>Ja</span></label>
-                        <label class="flex items-center space-x-2 cursor-pointer"><input type="radio" name="answer-${q.id}" value="no" class="form-radio h-4 w-4 text-blue-600"><span>Nee</span></label>
-                        <label class="flex items-center space-x-2 cursor-pointer"><input type="radio" name="answer-${q.id}" value="na" class="form-radio h-4 w-4 text-blue-600" checked><span>N.v.t.</span></label>
-                    `;
-                    if (type === 'ib' || type === 'client') {
-                        radioContainer.addEventListener('change', (e) => handleAnswerChange(questionWrapper, q, e.target.value));
-                    }
-                    contentWrapper.appendChild(radioContainer);
-                }
-                
-                // Comment and Rollover section
-                const commentContainer = document.createElement('div');
-                commentContainer.className = 'mt-3 space-y-2';
-                commentContainer.innerHTML = `
-                    <textarea id="comment-${q.id}" class="w-full p-2 border border-gray-300 rounded-md text-sm" placeholder="Voeg commentaar toe..."></textarea>
-                    <label class="flex items-center space-x-2 cursor-pointer text-sm text-gray-600">
-                        <input type="checkbox" id="comment-rollover-${q.id}" class="form-checkbox h-4 w-4 text-blue-600 rounded">
-                        <span>Commentaar overnemen naar volgend jaar</span>
-                    </label>
-                `;
-                contentWrapper.appendChild(commentContainer);
-
-                const uploadContainer = document.createElement('div');
-                uploadContainer.className = 'mt-3 flex items-center gap-x-2';
-                uploadContainer.innerHTML = `
-                    <input type="file" id="file-${q.id}" class="text-sm text-gray-500 file:mr-4 file:py-1 file:px-2 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"/>
-                    <button class="upload-btn text-xs bg-gray-200 hover:bg-gray-300 text-gray-700 py-1 px-2 rounded-md">Upload</button>
-                    <span id="upload-status-${q.id}" class="text-xs text-green-600"></span>
-                `;
-                uploadContainer.querySelector('.upload-btn').addEventListener('click', () => handleFileUpload(q.id));
-                contentWrapper.appendChild(uploadContainer);
-                questionWrapper.appendChild(contentWrapper);
-
-                if (hasChildren) {
-                    const childrenContainer = document.createElement('div');
-                    childrenContainer.className = 'sub-question';
-                    renderQuestions(q.children, childrenContainer, type);
-                    questionWrapper.appendChild(childrenContainer);
-                }
-                return questionWrapper;
-            }
-            
-            function handleAnswerChange(element, question, answer) {
-                const condition = question.condition;
-                if (!condition) return;
-                const shouldTrigger = (condition.on === answer);
-                if (condition.action === 'hide_children') {
-                    shouldTrigger ? element.removeAttribute('open') : element.setAttribute('open', '');
-                } else if (condition.action === 'skip') {
-                    const allQuestions = document.querySelectorAll('.question-container');
-                    const startSkipId = parseInt(question.id, 10) + 1, endSkipId = parseInt(condition.target, 10);
-                    allQuestions.forEach(el => {
-                        const currentId = parseInt(el.dataset.questionId, 10);
-                        if (currentId >= startSkipId && currentId < endSkipId) el.classList.toggle('hidden', shouldTrigger);
-                    });
-                }
-            }
-            
-            function handleFileUpload(questionId) {
-                const apiKey = document.getElementById('api-key-input').value;
-                if (!apiKey) {
-                    showToast("Fout: AuditCase X-API-KEY ontbreekt.");
-                    console.error("MOCK API CALL FAILED: Status 400 (Bad Request) - X-API-KEY header is missing.");
-                    return;
-                }
-                const fileInput = document.getElementById(`file-${questionId}`), statusEl = document.getElementById(`upload-status-${questionId}`);
-                if (fileInput.files.length > 0) {
-                    statusEl.textContent = 'Uploading...';
-                    setTimeout(() => { 
-                        statusEl.textContent = `✔ ${fileInput.files[0].name} uploaded.`; 
-                        showToast(`Bestand ${fileInput.files[0].name} verzonden naar AuditCase.`);
-                        console.log(`MOCK API CALL: POST /ac/api/document/dossier/create/... with X-API-KEY: ${apiKey.substring(0,8)}...`);
-                        console.log(`MOCK API RESPONSE: Status 201 (Created)`);
-                    }, 1000);
-                } else {
-                    showToast("Selecteer eerst een bestand.");
-                }
-            }
-            
-            function showToast(message) {
-                const toast = document.getElementById('toast');
-                toast.textContent = message;
-                toast.classList.add('show');
-                setTimeout(() => toast.classList.remove('show'), 3000);
-            }
-
-            // --- Initialize the App ---
-            init();
-        });
-    </script>
-</body>
+    <script type="module" src="js/app.js"></script>
+  </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,539 @@
+import {
+  parseMarkdownToList,
+  parseMarkdownFromTable,
+} from './markdown-parser.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  // --- App State ---
+  let currentProgram = null;
+  let currentUser = null;
+  let dossierStatus = 'open'; // 'open', 'ingediend', 'gereviewd', 'afgesloten'
+  let availableYears = [];
+
+  // --- DOM Element References ---
+  const dom = {
+    dashboardScreen: document.getElementById('dashboard-screen'),
+    werkprogrammaScreen: document.getElementById('werkprogramma-screen'),
+    btnLogout: document.getElementById('btn-logout'),
+    userDisplayDashboard: document.getElementById('user-display-dashboard'),
+    userDisplayWerkprogramma: document.getElementById(
+      'user-display-werkprogramma',
+    ),
+    apiKeyInput: document.getElementById('api-key-input'),
+    fiscalYearSelect: document.getElementById('fiscal-year-select'),
+    btnAddYear: document.getElementById('btn-add-year'),
+    btnIb: document.getElementById('btn-ib'),
+    btnVpb: document.getElementById('btn-vpb'),
+    clientSelectionContainer: document.getElementById(
+      'client-selection-container',
+    ),
+    clientSelect: document.getElementById('client-select'),
+    btnOpenWerkprogramma: document.getElementById('btn-open-werkprogramma'),
+    btnBackToDashboard: document.getElementById('btn-back-to-dashboard'),
+    headerSubtitle: document.getElementById('header-subtitle'),
+    werkprogrammaContainer: document.getElementById('werkprogramma-container'),
+    dossierStatusContainer: document.getElementById('dossier-status-container'),
+    dossierStatusBadge: document.getElementById('dossier-status-badge'),
+    btnSubmit: document.getElementById('btn-submit'),
+    btnReview: document.getElementById('btn-review'),
+    btnClose: document.getElementById('btn-close'),
+    btnReopen: document.getElementById('btn-reopen'),
+    btnExport: document.getElementById('btn-export'),
+    importFile: document.getElementById('import-file'),
+  };
+
+  // --- Data ---
+  const clients = {
+    ib: ['Jan Jansen', 'Pim Jansen', 'Anne de Jong'],
+    vpb: ['Test B.V.', 'Test 2 B.V.', 'Holding X B.V.'],
+  };
+  const permissions = {
+    opsteller: {
+      canSubmit: true,
+      canReview: false,
+      canClose: false,
+      canReopen: false,
+      canAddYear: false,
+    },
+    reviewer: {
+      canSubmit: true,
+      canReview: true,
+      canClose: true,
+      canReopen: true,
+      canAddYear: true,
+    },
+    admin: {
+      canSubmit: true,
+      canReview: true,
+      canClose: true,
+      canReopen: true,
+      canAddYear: true,
+    },
+  };
+
+  // --- Initialization ---
+  async function init() {
+    const token = sessionStorage.getItem('token');
+    if (!token) {
+      window.location.href = 'login.html';
+      return;
+    }
+    try {
+      const res = await fetch('/api/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error('Unauthorized');
+      const data = await res.json();
+      currentUser = data.user;
+    } catch (err) {
+      window.location.href = 'login.html';
+      return;
+    }
+
+    const currentYear = new Date().getFullYear();
+    availableYears = [currentYear, currentYear - 1, currentYear - 2];
+    populateFiscalYears();
+
+    // Event Listeners
+    dom.btnLogout.addEventListener('click', handleLogout);
+    dom.btnAddYear.addEventListener('click', handleAddYear);
+    dom.btnIb.addEventListener('click', () => setupClientSelection('ib'));
+    dom.btnVpb.addEventListener('click', () => setupClientSelection('vpb'));
+    dom.clientSelect.addEventListener('change', () => {
+      dom.btnOpenWerkprogramma.disabled = !dom.clientSelect.value;
+    });
+    dom.btnOpenWerkprogramma.addEventListener('click', openWerkprogramma);
+    dom.btnBackToDashboard.addEventListener('click', showDashboard);
+    dom.btnExport.addEventListener('click', handleExport);
+    dom.importFile.addEventListener('change', handleImport);
+
+    dom.btnSubmit.addEventListener('click', () =>
+      updateDossierStatus('ingediend', 'Dossier ingediend.'),
+    );
+    dom.btnReview.addEventListener('click', () =>
+      updateDossierStatus('gereviewd', 'Dossier gereviewd.'),
+    );
+    dom.btnClose.addEventListener('click', () =>
+      updateDossierStatus('afgesloten', 'Dossier afgesloten.'),
+    );
+    dom.btnReopen.addEventListener('click', () => {
+      const reason = prompt('Reden voor heropenen:');
+      if (reason && reason.trim() !== '') {
+        console.log(
+          `MOCK AUDIT TRAIL: Dossier heropend door ${currentUser.name}. Reden: ${reason}`,
+        );
+        updateDossierStatus('open', 'Dossier heropend.');
+      } else if (reason !== null) {
+        showToast('Een reden is verplicht om het dossier te heropenen.');
+      }
+    });
+
+    dom.userDisplayDashboard.textContent = `Ingelogd als: ${currentUser.name}`;
+    dom.userDisplayWerkprogramma.textContent = `Ingelogd als: ${currentUser.name}`;
+    dom.btnAddYear.classList.toggle(
+      'hidden',
+      !permissions[currentUser.role].canAddYear,
+    );
+
+    showDashboard();
+  }
+
+  // --- Core Functions ---
+  function populateFiscalYears() {
+    dom.fiscalYearSelect.innerHTML = '';
+    availableYears
+      .sort((a, b) => b - a)
+      .forEach((year) => {
+        dom.fiscalYearSelect.appendChild(new Option(year, year));
+      });
+  }
+
+  async function handleLogout() {
+    const token = sessionStorage.getItem('token');
+    try {
+      await fetch('/api/logout', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch (e) {}
+    sessionStorage.removeItem('token');
+    sessionStorage.removeItem('currentUser');
+    window.location.href = 'login.html';
+  }
+
+  function handleAddYear() {
+    const latestYear = Math.max(...availableYears);
+    const newYear = prompt('Voer het nieuwe fiscale jaar in:', latestYear + 1);
+    if (newYear && !isNaN(newYear) && newYear > 1900) {
+      const year = parseInt(newYear, 10);
+      if (availableYears.includes(year)) {
+        showToast(`Fiscaal jaar ${year} bestaat al.`);
+        return;
+      }
+      availableYears.push(year);
+      populateFiscalYears();
+      dom.fiscalYearSelect.value = year;
+      showToast(
+        `Fiscaal jaar ${year} aangemaakt. Commentaren met 'doorrol' optie zijn (gesimuleerd) overgenomen.`,
+      );
+    } else if (newYear !== null) {
+      showToast('Ongeldig jaartal ingevoerd.');
+    }
+  }
+
+  function showDashboard() {
+    dom.dashboardScreen.classList.remove('hidden');
+    dom.werkprogrammaScreen.classList.add('hidden');
+  }
+
+  function openWerkprogramma() {
+    if (!currentProgram || !dom.clientSelect.value) return;
+    dom.dashboardScreen.classList.add('hidden');
+    dom.werkprogrammaScreen.classList.remove('hidden');
+    dossierStatus = 'open';
+    loadAndRenderWorkProgram(
+      currentProgram,
+      dom.clientSelect.value,
+      dom.fiscalYearSelect.value,
+    );
+  }
+
+  function setupClientSelection(programType) {
+    currentProgram = programType;
+    setActiveButton(
+      programType === 'ib' ? dom.btnIb : dom.btnVpb,
+      '.program-btn',
+    );
+
+    dom.clientSelect.innerHTML = '<option value="">-- Selecteer --</option>';
+    clients[programType].forEach((client) => {
+      dom.clientSelect.appendChild(new Option(client, client));
+    });
+
+    dom.clientSelectionContainer.classList.remove('hidden');
+    dom.btnOpenWerkprogramma.disabled = true;
+  }
+
+  function updateDossierStatus(newStatus, toastMessage) {
+    dossierStatus = newStatus;
+    updateUIForRoleAndStatus();
+    showToast(toastMessage);
+  }
+
+  function updateUIForRoleAndStatus() {
+    if (!currentUser) return;
+    const rolePerms = permissions[currentUser.role];
+    const isLocked = dossierStatus === 'afgesloten';
+
+    dom.dossierStatusBadge.textContent =
+      dossierStatus.charAt(0).toUpperCase() + dossierStatus.slice(1);
+    dom.dossierStatusBadge.className =
+      'font-bold px-2 py-1 rounded-full ' +
+      (isLocked ? 'bg-red-200 text-red-800' : 'bg-green-200 text-green-800');
+    if (dom.clientSelect.value) {
+      dom.dossierStatusContainer.classList.remove('hidden');
+    }
+
+    const fieldset = document.getElementById('form-fieldset');
+    if (fieldset) {
+      fieldset.disabled = isLocked && currentUser.role === 'opsteller';
+    }
+
+    dom.btnSubmit.classList.toggle(
+      'hidden',
+      !rolePerms.canSubmit || dossierStatus !== 'open',
+    );
+    dom.btnReview.classList.toggle(
+      'hidden',
+      !rolePerms.canReview || dossierStatus !== 'ingediend',
+    );
+    dom.btnClose.classList.toggle(
+      'hidden',
+      !rolePerms.canClose || dossierStatus !== 'gereviewd',
+    );
+    dom.btnReopen.classList.toggle('hidden', !rolePerms.canReopen || !isLocked);
+  }
+
+  async function loadAndRenderWorkProgram(type, clientName, fiscalYear) {
+    dom.werkprogrammaContainer.innerHTML = `<div class="text-center p-8"><p class="text-gray-500">Werkprogramma wordt geladen...</p></div>`;
+    dom.headerSubtitle.textContent = `Werkprogramma ${type.toUpperCase()} voor ${clientName} - Fiscaal Jaar ${fiscalYear}`;
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      const [clientMd, taxMd] = await Promise.all([
+        fetch('werkprogramma_client.md').then((r) => r.text()),
+        fetch(
+          type === 'ib'
+            ? 'werkprogramma_inkomstenbelasting.md'
+            : 'werkprogramma_vennootschapsbelasting.md',
+        ).then((r) => r.text()),
+      ]);
+      const clientQuestions = parseMarkdownToList(clientMd);
+      const taxQuestions =
+        type === 'ib'
+          ? parseMarkdownToList(taxMd)
+          : parseMarkdownFromTable(taxMd);
+
+      dom.werkprogrammaContainer.innerHTML = `
+        <fieldset id="form-fieldset">
+          <div class="border-b border-gray-200">
+            <nav class="-mb-px flex space-x-8" aria-label="Tabs">
+              <button id="tab-client" class="tab-btn whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">Klant</button>
+              <button id="tab-tax" class="tab-btn whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">Aangifte</button>
+            </nav>
+          </div>
+          <div id="client-pane" class="content-pane py-4"></div>
+          <div id="tax-pane" class="content-pane py-4 hidden"></div>
+        </fieldset>`;
+
+      const clientPane = document.getElementById('client-pane');
+      const taxPane = document.getElementById('tax-pane');
+      renderQuestions(clientQuestions, clientPane, 'client');
+      renderQuestions(taxQuestions, taxPane, type);
+
+      const tabClient = document.getElementById('tab-client');
+      const tabTax = document.getElementById('tab-tax');
+
+      setActiveButton(tabClient, '.tab-btn');
+      tabClient.addEventListener('click', () => {
+        setActiveButton(tabClient, '.tab-btn');
+        clientPane.classList.remove('hidden');
+        taxPane.classList.add('hidden');
+      });
+      tabTax.addEventListener('click', () => {
+        setActiveButton(tabTax, '.tab-btn');
+        clientPane.classList.add('hidden');
+        taxPane.classList.remove('hidden');
+      });
+
+      updateUIForRoleAndStatus();
+    } catch (error) {
+      console.error(`Failed to load work program for ${type}:`, error);
+      dom.werkprogrammaContainer.innerHTML =
+        '<p class="text-red-500 text-center">Fout bij het laden van het werkprogramma.</p>';
+    }
+  }
+
+  // --- Import/Export Functions ---
+  function handleExport() {
+    let content = `# Werkprogramma ${currentProgram.toUpperCase()} - ${dom.clientSelect.value}\n`;
+    content += `# Fiscaal Jaar: ${dom.fiscalYearSelect.value}\n`;
+    content += `# Status: ${dossierStatus}\n\n`;
+
+    document.querySelectorAll('.question-container').forEach((q) => {
+      const id = q.dataset.questionId;
+      if (!id) return;
+      const text = q.querySelector('p').textContent.replace(`${id}. `, '');
+      const checkedRadio = q.querySelector(
+        `input[name="answer-${id}"]:checked`,
+      );
+      const comment = q.querySelector(`#comment-${id}`).value;
+      const rollover = q.querySelector(`#comment-rollover-${id}`).checked;
+
+      if (checkedRadio) {
+        const answer = checkedRadio.parentElement.textContent.trim();
+        content += `${id}. ${text}\n`;
+        content += `   Antwoord: ${answer}\n`;
+        content += `   Commentaar: ${comment}\n`;
+        content += `   Doorrollen: ${rollover ? 'Ja' : 'Nee'}\n\n`;
+      }
+    });
+
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `werkprogramma-${dom.clientSelect.value.replace(/ /g, '_')}-${dom.fiscalYearSelect.value}.txt`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+    showToast('Dossier geëxporteerd.');
+  }
+
+  function handleImport(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target.result;
+      const lines = content.split('\n');
+      let currentId = null;
+
+      lines.forEach((line) => {
+        let match;
+        if ((match = line.match(/^([0-9a-zA-Z]+)\./))) {
+          currentId = match[1];
+        } else if (
+          currentId &&
+          (match = line.match(/^\s+Antwoord:\s(Ja|Nee|N\.v\.t\.)/i))
+        ) {
+          const answer = match[1].toLowerCase().replace('n.v.t.', 'na');
+          const radio = document.querySelector(
+            `input[name="answer-${currentId}"][value="${answer}"]`,
+          );
+          if (radio) {
+            radio.checked = true;
+            radio.dispatchEvent(new Event('change', { bubbles: true }));
+          }
+        } else if (currentId && (match = line.match(/^\s+Commentaar:\s(.*)/))) {
+          const commentEl = document.getElementById(`comment-${currentId}`);
+          if (commentEl) commentEl.value = match[1];
+        } else if (
+          currentId &&
+          (match = line.match(/^\s+Doorrollen:\s(Ja|Nee)/i))
+        ) {
+          const rolloverEl = document.getElementById(
+            `comment-rollover-${currentId}`,
+          );
+          if (rolloverEl) rolloverEl.checked = match[1].toLowerCase() === 'ja';
+        }
+      });
+      showToast('Dossier geïmporteerd.');
+    };
+    reader.readAsText(file);
+    event.target.value = '';
+  }
+
+  // --- Utility Functions ---
+  function setActiveButton(activeButton, selector) {
+    document
+      .querySelectorAll(selector)
+      .forEach((btn) => btn.classList.remove('active'));
+    if (activeButton) activeButton.classList.add('active');
+  }
+
+  function renderQuestions(questions, container, type) {
+    questions.forEach((q) =>
+      container.appendChild(createQuestionElement(q, type)),
+    );
+  }
+
+  function createQuestionElement(q, type) {
+    if (q.isHeading) {
+      const heading = document.createElement('h2');
+      heading.className = 'werkprogramma-heading';
+      heading.textContent = q.text;
+      return heading;
+    }
+
+    const hasChildren = q.children && q.children.length > 0;
+    const questionWrapper = document.createElement(
+      hasChildren ? 'details' : 'div',
+    );
+    questionWrapper.className =
+      'question-container py-4 border-b border-gray-200';
+    questionWrapper.id = `question-${q.id}`;
+    questionWrapper.dataset.questionId = q.id;
+
+    const contentWrapper = document.createElement(
+      hasChildren ? 'summary' : 'div',
+    );
+
+    const questionText = document.createElement('p');
+    questionText.className = 'font-semibold text-gray-700 inline';
+    questionText.textContent = q.isDetail ? q.text : `${q.id}. ${q.text}`;
+    contentWrapper.appendChild(questionText);
+
+    if (!q.isDetail) {
+      const radioContainer = document.createElement('div');
+      radioContainer.className = 'mt-2 flex items-center gap-x-6';
+      radioContainer.innerHTML = `
+        <label class="flex items-center space-x-2 cursor-pointer"><input type="radio" name="answer-${q.id}" value="yes" class="form-radio h-4 w-4 text-blue-600"><span>Ja</span></label>
+        <label class="flex items-center space-x-2 cursor-pointer"><input type="radio" name="answer-${q.id}" value="no" class="form-radio h-4 w-4 text-blue-600"><span>Nee</span></label>
+        <label class="flex items-center space-x-2 cursor-pointer"><input type="radio" name="answer-${q.id}" value="na" class="form-radio h-4 w-4 text-blue-600" checked><span>N.v.t.</span></label>`;
+      if (type === 'ib' || type === 'client') {
+        radioContainer.addEventListener('change', (e) =>
+          handleAnswerChange(questionWrapper, q, e.target.value),
+        );
+      }
+      contentWrapper.appendChild(radioContainer);
+    }
+
+    const commentContainer = document.createElement('div');
+    commentContainer.className = 'mt-3 space-y-2';
+    commentContainer.innerHTML = `
+      <textarea id="comment-${q.id}" class="w-full p-2 border border-gray-300 rounded-md text-sm" placeholder="Voeg commentaar toe..." aria-label="Commentaar"></textarea>
+      <label class="flex items-center space-x-2 cursor-pointer text-sm text-gray-600">
+        <input type="checkbox" id="comment-rollover-${q.id}" class="form-checkbox h-4 w-4 text-blue-600 rounded">
+        <span>Commentaar overnemen naar volgend jaar</span>
+      </label>`;
+    contentWrapper.appendChild(commentContainer);
+
+    const uploadContainer = document.createElement('div');
+    uploadContainer.className = 'mt-3 flex items-center gap-x-2';
+    uploadContainer.innerHTML = `
+      <input type="file" id="file-${q.id}" class="text-sm text-gray-500 file:mr-4 file:py-1 file:px-2 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" aria-label="Upload bestand"/>
+      <button class="upload-btn text-xs bg-gray-200 hover:bg-gray-300 text-gray-700 py-1 px-2 rounded-md">Upload</button>
+      <span id="upload-status-${q.id}" class="text-xs text-green-600"></span>`;
+    uploadContainer
+      .querySelector('.upload-btn')
+      .addEventListener('click', () => handleFileUpload(q.id));
+    contentWrapper.appendChild(uploadContainer);
+    questionWrapper.appendChild(contentWrapper);
+
+    if (hasChildren) {
+      const childrenContainer = document.createElement('div');
+      childrenContainer.className = 'sub-question';
+      renderQuestions(q.children, childrenContainer, type);
+      questionWrapper.appendChild(childrenContainer);
+    }
+    return questionWrapper;
+  }
+
+  function handleAnswerChange(element, question, answer) {
+    const condition = question.condition;
+    if (!condition) return;
+    const shouldTrigger = condition.on === answer;
+    if (condition.action === 'hide_children') {
+      shouldTrigger
+        ? element.removeAttribute('open')
+        : element.setAttribute('open', '');
+    } else if (condition.action === 'skip') {
+      const allQuestions = document.querySelectorAll('.question-container');
+      const startSkipId = parseInt(question.id, 10) + 1;
+      const endSkipId = parseInt(condition.target, 10);
+      allQuestions.forEach((el) => {
+        const currentId = parseInt(el.dataset.questionId, 10);
+        if (currentId >= startSkipId && currentId < endSkipId)
+          el.classList.toggle('hidden', shouldTrigger);
+      });
+    }
+  }
+
+  function handleFileUpload(questionId) {
+    const apiKey = document.getElementById('api-key-input').value;
+    if (!apiKey) {
+      showToast('Fout: AuditCase X-API-KEY ontbreekt.');
+      console.error(
+        'MOCK API CALL FAILED: Status 400 (Bad Request) - X-API-KEY header is missing.',
+      );
+      return;
+    }
+    const fileInput = document.getElementById(`file-${questionId}`);
+    const statusEl = document.getElementById(`upload-status-${questionId}`);
+    if (fileInput.files.length > 0) {
+      statusEl.textContent = 'Uploading...';
+      setTimeout(() => {
+        statusEl.textContent = `✔ ${fileInput.files[0].name} uploaded.`;
+        showToast(
+          `Bestand ${fileInput.files[0].name} verzonden naar AuditCase.`,
+        );
+        console.log(
+          `MOCK API CALL: POST /ac/api/document/dossier/create/... with X-API-KEY: ${apiKey.substring(0, 8)}...`,
+        );
+        console.log('MOCK API RESPONSE: Status 201 (Created)');
+      }, 1000);
+    } else {
+      showToast('Selecteer eerst een bestand.');
+    }
+  }
+
+  function showToast(message) {
+    const toast = document.getElementById('toast');
+    toast.textContent = message;
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 3000);
+  }
+
+  // --- Initialize the App ---
+  init();
+});

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('login-form');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (!res.ok) throw new Error('Login failed');
+      const data = await res.json();
+      sessionStorage.setItem('token', data.token);
+      sessionStorage.setItem('currentUser', JSON.stringify(data.user));
+      window.location.href = 'index.html';
+    } catch (err) {
+      alert('Login mislukt');
+    }
+  });
+});

--- a/js/markdown-parser.js
+++ b/js/markdown-parser.js
@@ -1,0 +1,91 @@
+export function parseMarkdownToList(markdown) {
+  const lines = markdown.split('\n');
+  const questions = [];
+  const stack = [{ children: questions, level: -1 }];
+  const headingRegex = /^##\s+(.*)/;
+  const mainQRegex = /^(\d+)\.\s*(.*)/;
+  const subQRegex = /^\s+([a-zA-Z])\.\s*(.*)/;
+  const detailQRegex = /^\s+-\s*(.*)/;
+
+  lines.forEach((line) => {
+    let match;
+    if ((match = line.match(headingRegex))) {
+      questions.push({ isHeading: true, text: match[1].trim() });
+      stack.length = 1;
+    } else if ((match = line.match(mainQRegex))) {
+      let text = match[2].trim();
+      const condition = parseCondition(text);
+      if (condition) text = text.replace(/Zo nee,.*|Zo ja,.*/i, '').trim();
+      const question = {
+        id: match[1],
+        text,
+        children: [],
+        condition,
+        level: 0,
+      };
+      questions.push(question);
+      stack.length = 1;
+      stack.push(question);
+    } else if ((match = line.match(subQRegex))) {
+      while (stack.length > 2 && stack[stack.length - 1].level >= 1) {
+        stack.pop();
+      }
+      const parent = stack[stack.length - 1];
+      const id = `${parent.id}${match[1]}`;
+      const question = {
+        id,
+        text: match[2].trim(),
+        children: [],
+        level: parent.level + 1,
+      };
+      parent.children.push(question);
+      stack.push(question);
+    } else if ((match = line.match(detailQRegex))) {
+      const parent = stack[stack.length - 1];
+      const id = `${parent.id}-${parent.children.length + 1}`;
+      parent.children.push({
+        id,
+        text: match[1].trim(),
+        level: parent.level + 1,
+        isDetail: true,
+      });
+    }
+  });
+  return questions;
+}
+
+export function parseMarkdownFromTable(markdown) {
+  const lines = markdown.split('\n');
+  const questions = [];
+  const vpbQRegex = /^\|\s*(\d+)\s*\|([^|]+)\|/;
+  const headingRegex = /^##\s+(.*)/;
+  lines.forEach((line) => {
+    let match;
+    if ((match = line.match(headingRegex))) {
+      questions.push({ isHeading: true, text: match[1].trim() });
+    } else if ((match = line.match(vpbQRegex))) {
+      questions.push({
+        id: match[1].trim(),
+        text: match[2].trim().replace(/<br>/g, ' '),
+        children: [],
+        level: 0,
+      });
+    }
+  });
+  return questions;
+}
+
+function parseCondition(text) {
+  const skipMatch = text.match(
+    /Zo (nee|ja)[\s,:]*(?:ga naar vraag|ga naar)\s*(\d+)/i,
+  );
+  if (skipMatch)
+    return {
+      on: skipMatch[1].toLowerCase(),
+      action: 'skip',
+      target: skipMatch[2],
+    };
+  if (/Zo nee, ga naar vraag \d+/.test(text))
+    return { on: 'no', action: 'hide_children' };
+  return null;
+}

--- a/login.html
+++ b/login.html
@@ -1,47 +1,58 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="nl">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Inloggen - Werkprogramma IB & VPB</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        #login-screen {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            height: 100vh;
-        }
-    </style>
-</head>
-<body class="bg-gray-100 font-sans">
+    <link rel="stylesheet" href="css/styles.css" />
+  </head>
+  <body class="bg-gray-100 font-sans">
     <div id="login-screen">
-        <div class="bg-white p-8 rounded-lg shadow-md text-center w-full max-w-sm">
-            <h1 class="text-2xl font-bold text-gray-800 mb-4">Inloggen</h1>
-            <p class="text-gray-600 mb-6">Selecteer een gebruiker om in te loggen.</p>
-            <select id="user-select" class="w-full p-2 border border-gray-300 rounded-md mb-4"></select>
-            <button id="btn-login" class="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition">Login</button>
-        </div>
+      <div
+        class="bg-white p-8 rounded-lg shadow-md text-center w-full max-w-sm"
+      >
+        <h1 class="text-2xl font-bold text-gray-800 mb-4">Inloggen</h1>
+        <form id="login-form" class="space-y-4" aria-label="Inlogformulier">
+          <div class="text-left">
+            <label
+              for="username"
+              class="block text-sm font-medium text-gray-700"
+              >Gebruikersnaam</label
+            >
+            <input
+              id="username"
+              type="text"
+              class="w-full p-2 border border-gray-300 rounded-md"
+              aria-label="Gebruikersnaam"
+              required
+            />
+          </div>
+          <div class="text-left">
+            <label
+              for="password"
+              class="block text-sm font-medium text-gray-700"
+              >Wachtwoord</label
+            >
+            <input
+              id="password"
+              type="password"
+              class="w-full p-2 border border-gray-300 rounded-md"
+              aria-label="Wachtwoord"
+              required
+            />
+          </div>
+          <button
+            id="btn-login"
+            type="submit"
+            class="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition"
+            aria-label="Login"
+          >
+            Login
+          </button>
+        </form>
+      </div>
     </div>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const users = {
-                alice: { name: "Alice (Opsteller)", role: "opsteller" },
-                bob: { name: "Bob (Reviewer)", role: "reviewer" },
-                charlie: { name: "Charlie (Admin)", role: "admin" }
-            };
-            const userSelect = document.getElementById('user-select');
-            Object.keys(users).forEach(id => {
-                userSelect.appendChild(new Option(users[id].name, id));
-            });
-            document.getElementById('btn-login').addEventListener('click', () => {
-                const selected = userSelect.value;
-                if (!selected) return;
-                localStorage.setItem('currentUser', selected);
-                window.location.href = 'index.html';
-            });
-        });
-    </script>
-</body>
+    <script type="module" src="js/login.js"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "werkprogramma_ib_vpb",
+  "version": "1.0.0",
+  "description": "Vastleggingsprogramma voor fiscale aangiftes inkomstenbelasting en vennootschapsbelasting met drie delen: 1. **Klant** klantdossier, UBO, paspoort, KYC, opdrachtbevestiging 2. **Vastleggingsprogramma** workflow en audit trail voor IB en VPB 3. **Reviewer-only** afsluiten en vergrendelen van dossiers voor iedereen behalve reviewers",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.0.0",
+    "prettier": "^2.8.0",
+    "jest": "^29.0.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+const app = express();
+app.use(express.json());
+
+const users = {
+  alice: { password: 'password', name: 'Alice (Opsteller)', role: 'opsteller' },
+  bob: { password: 'password', name: 'Bob (Reviewer)', role: 'reviewer' },
+  charlie: { password: 'password', name: 'Charlie (Admin)', role: 'admin' },
+};
+
+const sessions = new Map();
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users[username];
+  if (!user || user.password !== password) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const token = uuidv4();
+  sessions.set(token, username);
+  res.json({ token, user: { id: username, name: user.name, role: user.role } });
+});
+
+app.get('/api/me', (req, res) => {
+  const auth = req.headers.authorization || '';
+  const token = auth.replace('Bearer ', '');
+  const userId = sessions.get(token);
+  if (!userId) return res.status(401).end();
+  const user = users[userId];
+  res.json({ user: { id: userId, name: user.name, role: user.role } });
+});
+
+app.post('/api/logout', (req, res) => {
+  const auth = req.headers.authorization || '';
+  const token = auth.replace('Bearer ', '');
+  sessions.delete(token);
+  res.status(204).end();
+});
+
+app.use(express.static('.'));
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server running on port ${port}`));

--- a/werkprogramma_client.md
+++ b/werkprogramma_client.md
@@ -1,0 +1,9 @@
+## Klant acceptatie
+
+1. Is de opdrachtbevestiging getekend en opgeslagen in het dossier?
+2. Is er een kopie van het paspoort of identiteitsbewijs van de cliënt aanwezig?
+3. Is de UBO (Ultimate Beneficial Owner) vastgesteld en gedocumenteerd?
+   a. Zijn de UBO-verklaringen compleet en ondertekend?
+4. Is het KYC (Know Your Customer) proces volledig doorlopen?
+   a. Is de cliënt gecontroleerd op PEP (Politically Exposed Person) en sanctielijsten?
+   b. Is de uitkomst van de Wwft-check vastgelegd?


### PR DESCRIPTION
## Summary
- Move inline styles and scripts into external files and add ARIA labels
- Load markdown content dynamically and add unit tests for parsing utilities
- Introduce server-backed authentication with Express and session tokens

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_b_68adc6a840c0832fb2a95920c6e12c60