### PR TITLE
feat: add offline fallback login

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,11 @@ Gebruik secrets via environment variables en rotation
 
 ## GitHub Pages demo
 
-Open `login.html` to choose a user and then continue to `index.html` for the main application. These static pages include a placeholder for future integration with the AuditCase API.
+Open `login.html` to sign in and then continue to `index.html` for the main application.
+Use one of the demo accounts:
+
+- `alice` / `password`
+- `bob` / `password`
+- `charlie` / `password`
+
+Wanneer er geen backend beschikbaar is, valt de loginpagina terug op deze lokale demo-accounts zodat je de UI kunt verkennen. Als de server draait (`npm start`), worden dezelfde gegevens gevalideerd via de API.

--- a/js/login.js
+++ b/js/login.js
@@ -1,4 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const fallbackUsers = {
+    alice: { password: 'password', name: 'Alice (Opsteller)', role: 'opsteller' },
+    bob: { password: 'password', name: 'Bob (Reviewer)', role: 'reviewer' },
+    charlie: { password: 'password', name: 'Charlie (Admin)', role: 'admin' },
+  };
+
   const form = document.getElementById('login-form');
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -10,13 +16,26 @@ document.addEventListener('DOMContentLoaded', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),
       });
-      if (!res.ok) throw new Error('Login failed');
+      if (!res.ok) {
+        alert('Login mislukt');
+        return;
+      }
       const data = await res.json();
       sessionStorage.setItem('token', data.token);
       sessionStorage.setItem('currentUser', JSON.stringify(data.user));
       window.location.href = 'clients.html';
     } catch (err) {
-      alert('Login mislukt');
+      const user = fallbackUsers[username];
+      if (user && user.password === password) {
+        sessionStorage.setItem('token', 'local-token');
+        sessionStorage.setItem(
+          'currentUser',
+          JSON.stringify({ id: username, name: user.name, role: user.role }),
+        );
+        window.location.href = 'clients.html';
+      } else {
+        alert('Login mislukt');
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- Allow login page to fall back to local demo accounts when backend is unavailable
- Document demo login credentials and fallback behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b1763447b8832f85e2e83df4aab660